### PR TITLE
Fix case:

### DIFF
--- a/Bson.HilbertIndex.Test/TestHilbertCode.cs
+++ b/Bson.HilbertIndex.Test/TestHilbertCode.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 namespace Bson.HilbertIndex.Test
 {
+    [TestFixture]
     public class Tests
     {
         [SetUp]
@@ -247,6 +248,32 @@ namespace Bson.HilbertIndex.Test
             }
             stopWatch.Stop();
             TestContext.WriteLine("Searched in: " + stopWatch.ElapsedMilliseconds);
+        }
+
+        [Test]
+        public void Index_Should_Handle_Searches_In_One_Item_Collection()
+        {
+            var index = new HilbertIndex<Poi>(new List<Poi> {
+                Poi.Create(id:1, categoryId: 1, new Coordinate(18.108183, 59.255583))
+            });
+
+            var result = index.NearestNeighbours(new Coordinate(18.11139, 59.25455));
+            Assert.AreEqual(1, result.Count());
+
+            result = index.Within(new Coordinate(18.11139, 59.25455), meters: 1000);
+            Assert.AreEqual(1, result.Count());
+        }
+
+        [Test]
+        public void Index_Should_Handle_Searches_In_Empty_Collection()
+        {
+            var index = new HilbertIndex<Poi>(new List<Poi>());
+
+            var result = index.NearestNeighbours(new Coordinate(18.11139, 59.25455));
+            Assert.IsEmpty(result);
+
+            result = index.Within(new Coordinate(18.11139, 59.25455), meters: 1000);
+            Assert.IsEmpty(result);
         }
 
         private static IEnumerable<Poi> Generate(int number)

--- a/Bson.HilbertIndex/HilbertIndex.cs
+++ b/Bson.HilbertIndex/HilbertIndex.cs
@@ -37,6 +37,11 @@ namespace Bson.HilbertIndex
 
         public IEnumerable<T> NearestNeighbours(Coordinate coordinate)
         {
+            if (!_items.Any())
+            {
+                return Enumerable.Empty<T>();
+            }
+
             ulong search1D = _hilbertCode.Encode(coordinate);
             int index = _items.BinarySearch(new Searchable(search1D), s_hilbertComparer);
 
@@ -46,10 +51,10 @@ namespace Bson.HilbertIndex
             {
                 neighbour1D = _items[index].Hid;
             }
-            // Matched last
-            else if (~index == _items.Count - 1)
+            // Matched last (or last + 1 meaning)
+            else if (~index >= _items.Count - 1)
             {
-                neighbour1D = _items[~index].Hid;
+                neighbour1D = _items[_items.Count - 1].Hid;
             }
             else
             {
@@ -79,14 +84,14 @@ namespace Bson.HilbertIndex
 
                 // Find index to start search.
                 int index = items.BinarySearch(startIndex, items.Count - startIndex, searchItem, s_hilbertComparer);
-                
+
                 // Got exact match. 
                 // To support items having duplicated hilbertIds, we "scan down" to find the first occurence of the matched hid
                 if (index > -1)
                 {
                     ulong hid = items[index].Hid;
                     int scanIndex = index - 1;
-                    while(scanIndex >= 0 && items[scanIndex].Hid == hid)
+                    while (scanIndex >= 0 && items[scanIndex].Hid == hid)
                         index = scanIndex -= 1;
                 }
 


### PR DESCRIPTION
Didn't support some searches on empty collection
Failed when nearest hilbert indices to search location was the last
item during a nearest neighbor search